### PR TITLE
Added scoping to the 'when I follow' step

### DIFF
--- a/browserstep/common.py
+++ b/browserstep/common.py
@@ -59,6 +59,15 @@ def step_impl(context, text):
     assert len(elements) == 1, "Expected 1 matching link, not {}".format(len(elements))
     elements[0].click()
 
+@step('I follow the "{text}" link in "{container_selector}"')
+def step_impl(context, container_selector, text):
+    container = context.browser.find_element_by_css_selector(container_selector)
+    elements = container.find_elements_by_link_text(text))
+    if not elements:
+        elements = container.find_elements_by_xpath("//img[contains(@alt,'{}')]".format(text))
+    assert len(elements) == 1, "Expected 1 matching link, not {}".format(len(elements))
+    elements[0].click()
+
 @step('I click the "{text}" button')
 def step_impl(context, text):
     element = context.browser.find_element_by_xpath("//button[contains(text(), '{}')] | //input[@type='submit' and contains(@value,'{}')]".format(text, text))

--- a/browserstep/common.py
+++ b/browserstep/common.py
@@ -62,7 +62,7 @@ def step_impl(context, text):
 @step('I follow the "{text}" link in "{container_selector}"')
 def step_impl(context, container_selector, text):
     container = context.browser.find_element_by_css_selector(container_selector)
-    elements = container.find_elements_by_link_text(text))
+    elements = container.find_elements_by_link_text(text)
     if not elements:
         elements = container.find_elements_by_xpath("//img[contains(@alt,'{}')]".format(text))
     assert len(elements) == 1, "Expected 1 matching link, not {}".format(len(elements))


### PR DESCRIPTION
When using browser step, I'm checking the behaviour of a specific component on the page (in my case, a menu), which might have the same link text as something else on the page (say, a footer, or some copy).

Because this checks the _whole_ page, anywhere else with the same text will cause a failing test - I want to be able to to scope a check so we're only checking within the elements specified by the selector.

Sound okay?
